### PR TITLE
added Namespaces for iOS

### DIFF
--- a/Assets/M2Mqtt/MqttClient.cs
+++ b/Assets/M2Mqtt/MqttClient.cs
@@ -55,6 +55,7 @@ using System.Collections;
 // (it's ambiguos with uPLibrary.Networking.M2Mqtt.Utility.Trace)
 using MqttUtility = uPLibrary.Networking.M2Mqtt.Utility;
 using System.IO;
+using System.Net.Security;
 
 namespace uPLibrary.Networking.M2Mqtt
 {

--- a/Assets/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/Assets/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -30,6 +30,8 @@ using System.Net.Sockets;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System;
+using System.Net.Security;
+using System.Security.Authentication;
 
 namespace uPLibrary.Networking.M2Mqtt
 {


### PR DESCRIPTION
## Status
**READY**

## Description
2 Files needed missing namespaces.
Adding those, does not break other platforms, but are needed to work on iOS.

## Tested on
- Unity 2019.3.13f1
- MacBook Pro 16" 2019 running MacOS Catalina 10.15.5
- iPad Pro 12,9" 4th Generation running iPadOS 13.5.1
- Huawei P30 Pro running Android 10